### PR TITLE
Updating debugBoot file to enable compilation debug in web.config to …

### DIFF
--- a/sitecore/9.0.1 rev. 171219 XM1/VS2017/SimpleSample/README.md
+++ b/sitecore/9.0.1 rev. 171219 XM1/VS2017/SimpleSample/README.md
@@ -99,4 +99,4 @@ If the solution is switched to the "Release" configuration re-run, the container
 
 ## Known issues
 
-1. Visual Studio fails when trying to attach just after starting debugging session. VS can attach to the running process in container afterwards, though. See section "Attaching VS2017 to Sitecore" for a workaround
+1. First time container is run, when copying in sitecore files, the debug operation times out, afterwards it should be working running with F5

--- a/sitecore/9.0.1 rev. 171219 XM1/VS2017/SimpleSample/Website/DebugBoot.ps1
+++ b/sitecore/9.0.1 rev. 171219 XM1/VS2017/SimpleSample/Website/DebugBoot.ps1
@@ -18,9 +18,15 @@ if ((Test-Path 'env:\DEFAULTWEBSITEPATH') -And (Test-Path 'env:\SITEPATH')){
 		Write-Host "### Sitecore files not found in '$WebsitePath', seeding clean Website ..."
 
 		Copy-Item -Path $DefaultWebsitePath -Destination $WebsitePath -Force -Recurse
+		$webConfig = Join-Path $WebsitePath "Web.config"
+		$doc = new-object System.Xml.XmlDocument
+		$doc.Load($webConfig)
+		$doc.get_DocumentElement()."system.web".compilation.debug = "true"
+		$doc.Save($webConfig)
 	}
 	else
 	{
 		Write-Host "### Existing Sitecore files found in '$WebsitePath'..."
 	}
+	
 }

--- a/sitecore/9.0.1 rev. 171219 XM1/VS2017/TDSSample/src/Website/DebugBoot.ps1
+++ b/sitecore/9.0.1 rev. 171219 XM1/VS2017/TDSSample/src/Website/DebugBoot.ps1
@@ -18,9 +18,15 @@ if ((Test-Path 'env:\DEFAULTWEBSITEPATH') -And (Test-Path 'env:\SITEPATH')){
 		Write-Host "### Sitecore files not found in '$WebsitePath', seeding clean Website ..."
 
 		Copy-Item -Path $DefaultWebsitePath -Destination $WebsitePath -Force -Recurse
+		$webConfig = Join-Path $WebsitePath "Web.config"
+		$doc = new-object System.Xml.XmlDocument
+		$doc.Load($webConfig)
+		$doc.get_DocumentElement()."system.web".compilation.debug = "true"
+		$doc.Save($webConfig)
 	}
 	else
 	{
 		Write-Host "### Existing Sitecore files found in '$WebsitePath'..."
 	}
+	
 }


### PR DESCRIPTION
The servicemonitor gets 403 error if the compilation debug attribute is not set to true.

known issue when first building the solution, powershell cant copy the files etc in a timely manor so msvsmon.exe doest startup fast enough. however after initially running it should work.