### PR TITLE
Fix two issues affecting CMCDSample in the development environment

### DIFF
--- a/sitecore/9.0.1 rev. 171219 XM1/VS2017/CMCDSample/Website/DebugBoot.ps1
+++ b/sitecore/9.0.1 rev. 171219 XM1/VS2017/CMCDSample/Website/DebugBoot.ps1
@@ -18,6 +18,11 @@ if ((Test-Path 'env:\DEFAULTWEBSITEPATH') -And (Test-Path 'env:\SITEPATH')){
 		Write-Host "### Sitecore files not found in '$WebsitePath', seeding clean Website ..."
 
 		Copy-Item -Path $DefaultWebsitePath -Destination $WebsitePath -Force -Recurse
+		$webConfig = Join-Path $WebsitePath "Web.config"
+		$doc = new-object System.Xml.XmlDocument
+		$doc.Load($webConfig)
+		$doc.get_DocumentElement()."system.web".compilation.debug = "true"
+		$doc.Save($webConfig)
 	}
 	else
 	{

--- a/sitecore/9.0.1 rev. 171219 XM1/VS2017/CMCDSample/docker-compose.dcproj
+++ b/sitecore/9.0.1 rev. 171219 XM1/VS2017/CMCDSample/docker-compose.dcproj
@@ -26,6 +26,12 @@
     <DockerServiceUrl>http://{ServiceIPAddress}</DockerServiceUrl>
     <DockerServiceName>cm</DockerServiceName>
   </PropertyGroup>
+  <PropertyGroup Label="Custom">
+    <DockerDevelopmentMode Condition=" '$(Configuration)' == 'DebugCD' ">Fast</DockerDevelopmentMode>
+    <DockerDevelopmentMode Condition=" '$(Configuration)' == 'DebugCM' ">Fast</DockerDevelopmentMode>
+    <DockerDevelopmentMode Condition=" '$(Configuration)' == 'ReleaseCD' ">Regular</DockerDevelopmentMode>
+    <DockerDevelopmentMode Condition=" '$(Configuration)' == 'ReleaseCM' ">Regular</DockerDevelopmentMode>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="docker-compose.vs.debug.yml">
       <DependentUpon>docker-compose.yml</DependentUpon>


### PR DESCRIPTION
The default VS2017 docker-compose project needs some custom properties in order to handle custom solution configuration with a name other than the default ones, "Debug" and "Release". This was causing issues to run the CD and CM containers in the development environment and has been solved.

A small change has also been introduced to facilitate the attachment of VS to the running containers for debugging.