### PR TITLE
fix: remove duplicate mssql-init services in xp1 override and rename …

### DIFF
--- a/custom-images/docker-compose.xp1.override.yml
+++ b/custom-images/docker-compose.xp1.override.yml
@@ -32,15 +32,7 @@ services:
       - ${LOCAL_DATA_PATH}\mssql:c:\data
 
   mssql-init:
-    image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-xp1-mssql:${VERSION:-latest}
-    build:
-      context: ./docker/build/mssql-init
-      args:
-        BASE_IMAGE: ${SITECORE_DOCKER_REGISTRY}sitecore-xp1-mssql-init:${SITECORE_VERSION}
-        SPE_IMAGE: ${SITECORE_MODULE_REGISTRY}sitecore-spe-assets:${SPE_VERSION}
-  
-  mssql-init:
-    image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-xp0-mssql-init:${VERSION:-latest}
+    image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-xp1-mssql-init:${VERSION:-latest}
     build:
       context: ./docker/build/mssql-init
       args:


### PR DESCRIPTION
Small fixes for a couple of things in the in the XP1 compose override:

- Remove duplicate mssql-init services in compose override
- Rename mssql-init image for consistency with other topologies.