### PR TITLE
Strip the X-Forwarded-Host header

### DIFF
--- a/custom-images/docker-compose.xm1.yml
+++ b/custom-images/docker-compose.xm1.yml
@@ -131,6 +131,8 @@ services:
       - "traefik.http.routers.cd-secure.entrypoints=websecure"
       - "traefik.http.routers.cd-secure.rule=Host(`${CD_HOST}`)"
       - "traefik.http.routers.cd-secure.tls=true"
+      - "traefik.http.middlewares.stripForwardedHostHeader.headers.customrequestheaders.X-Forwarded-Host="
+      - "traefik.http.routers.cd-secure.middlewares=stripForwardedHostHeader"
   cm:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cm:${SITECORE_VERSION}
@@ -170,4 +172,5 @@ services:
       - "traefik.http.routers.cm-secure.entrypoints=websecure"
       - "traefik.http.routers.cm-secure.rule=Host(`${CM_HOST}`)"
       - "traefik.http.routers.cm-secure.tls=true"
-      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header"
+      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header, stripForwardedHostHeader"
+      - "traefik.http.middlewares.stripForwardedHostHeader.headers.customrequestheaders.X-Forwarded-Host="

--- a/custom-images/docker-compose.xp1.yml
+++ b/custom-images/docker-compose.xp1.yml
@@ -144,6 +144,8 @@ services:
       - "traefik.http.routers.cd-secure.entrypoints=websecure"
       - "traefik.http.routers.cd-secure.rule=Host(`${CD_HOST}`)"
       - "traefik.http.routers.cd-secure.tls=true"
+      - "traefik.http.middlewares.stripForwardedHostHeader.headers.customrequestheaders.X-Forwarded-Host="
+      - "traefik.http.routers.cd-secure.middlewares=stripForwardedHostHeader"
   cm:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xp1-cm:${SITECORE_VERSION}
@@ -206,7 +208,8 @@ services:
       - "traefik.http.routers.cm-secure.entrypoints=websecure"
       - "traefik.http.routers.cm-secure.rule=Host(`${CM_HOST}`)"
       - "traefik.http.routers.cm-secure.tls=true"
-      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header"
+      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header, stripForwardedHostHeader"
+      - "traefik.http.middlewares.stripForwardedHostHeader.headers.customrequestheaders.X-Forwarded-Host="
   prc:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xp1-prc:${SITECORE_VERSION}

--- a/custom-images/docker-compose.yml
+++ b/custom-images/docker-compose.yml
@@ -144,7 +144,8 @@ services:
       - "traefik.http.routers.cm-secure.entrypoints=websecure"
       - "traefik.http.routers.cm-secure.rule=Host(`${CM_HOST}`)"
       - "traefik.http.routers.cm-secure.tls=true"
-      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header"
+      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header, stripForwardedHostHeader"
+      - "traefik.http.middlewares.stripForwardedHostHeader.headers.customrequestheaders.X-Forwarded-Host="
   xconnect:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xp0-xconnect:${SITECORE_VERSION}


### PR DESCRIPTION
**Issue:** You can't run Sitecore with Traefik on a different port than 443.

Traefik sends the X-Forwarded-Host header, which contains the same value as the Host header in the local setup. When sending traffic to Traefik on a non-standard HTTPS port (everything other then 443), this will lead into a Host and X-Forwarded-Host header as follows (using 8443 as port):
```
Host: myhost.local:8443
X-Forwarded-Host: myhost.local:8443
```

Unfortunately there's a bug in the logic that parses the X-Forwarded-Host header in Sitecore, which crashes when the value contains a port. The error is as follows:
```[UriFormatException: Invalid URI: The hostname could not be parsed.]
System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind) +261
System.UriBuilder.get_Uri() +60
Sitecore.Web.WebUtil.GetRequestUri(HttpContextBase context) +178
Sitecore.Pipelines.HttpRequest.OverrideDialogs.Process(PreprocessRequestArgs args) +41
(Object , Object ) +14
Sitecore.Pipelines.CorePipeline.Run(PipelineArgs args) +490
Sitecore.Pipelines.DefaultCorePipelineManager.Run(String pipelineName, PipelineArgs args, String pipelineDomain, Boolean failIfNotExists) +236
Sitecore.Pipelines.DefaultCorePipelineManager.Run(String pipelineName, PipelineArgs args, String pipelineDomain) +22
Sitecore.Web.RequestEventsHandler.OnBeginRequest(HttpContextBase context) +166
Sitecore.Nexus.Web.HttpModule.%E2%81%AB%E2%80%AB%E2%80%8E%E2%81%AA%E2%80%AE%E2%81%AC%E2%80%8C%E2%80%AE%E2%80%AC%E2%80%8D%E2%81%AF%E2%80%8D%E2%80%8E%E2%81%AF%E2%80%8D%E2%80%8B%E2%80%AA%E2%80%AC%E2%80%8E%E2%80%AD%E2%80%8F%E2%81%AF%E2%80%AC%E2%80%8D%E2%81%AA%E2%80%8D%E2%81%AA%E2%80%8C%E2%81%AF%E2%80%8D%E2%80%8D%E2%81%AD%E2%80%AB%E2%80%8E%E2%80%8B%E2%80%AA%E2%81%AA%E2%80%AA%E2%80%AB%E2%80%8C%E2%80%AE(Object , EventArgs ) +137
System.Web.SyncEventExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute() +223
System.Web.HttpApplication.ExecuteStepImpl(IExecutionStep step) +220
System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean&amp;amp; completedSynchronously) +94
```

This happens in Sitecore 9.2+, and is reported with public reference #455419 almost a year ago. This issue still isn't fixed at the moment, and causes the issue that you cannot run your Sitecore instances with Traefik on a different port then 443.