### PR TITLE
Fix volume mapping that will not work with docker-compose v2

### DIFF
--- a/custom-images/docker-compose.xm1.yml
+++ b/custom-images/docker-compose.xm1.yml
@@ -16,8 +16,8 @@ services:
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
     volumes:
-      - source: \\.\pipe\docker_engine
-        target: \\.\pipe\docker_engine
+      - source: \\.\pipe\docker_engine\
+        target: \\.\pipe\docker_engine\
         type: npipe
       - ./traefik:C:/etc/traefik
     depends_on:

--- a/custom-images/docker-compose.xp1.yml
+++ b/custom-images/docker-compose.xp1.yml
@@ -16,8 +16,8 @@ services:
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
     volumes:
-      - source: \\.\pipe\docker_engine
-        target: \\.\pipe\docker_engine
+      - source: \\.\pipe\docker_engine\
+        target: \\.\pipe\docker_engine\
         type: npipe
       - ./traefik:C:/etc/traefik
     depends_on:

--- a/custom-images/docker-compose.yml
+++ b/custom-images/docker-compose.yml
@@ -16,8 +16,8 @@ services:
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
     volumes:
-      - source: \\.\pipe\docker_engine
-        target: \\.\pipe\docker_engine
+      - source: \\.\pipe\docker_engine\
+        target: \\.\pipe\docker_engine\
         type: npipe
       - ./traefik:C:/etc/traefik
     depends_on:

--- a/getting-started/docker-compose.yml
+++ b/getting-started/docker-compose.yml
@@ -16,8 +16,8 @@ services:
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
     volumes:
-      - source: \\.\pipe\docker_engine
-        target: \\.\pipe\docker_engine
+      - source: \\.\pipe\docker_engine\
+        target: \\.\pipe\docker_engine\
         type: npipe
       - ./traefik:C:/etc/traefik
     depends_on:


### PR DESCRIPTION
**Issue**: Unable to run with docker compose V2.

When trying to run the examples with docker compose V2 enabled, the following error is shown:
```
Error response from daemon: Unrecognised volume spec: file '\\.\pipe\docker_engine' cannot be mapped. Only directories can be mapped on this platform
```

Due to this error you cannot start the examples unless you disable docker compose V2. This change will fix the volume spec.
