### PR TITLE
Updated containers docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sitecore Docker Examples
 
-This repository contains companion code for the [Sitecore Containers documentation](https://containers.doc.sitecore.com/). Together, these are meant to help you get started using [Docker](https://www.docker.com/) containers with Sitecore.
+This repository contains companion code for the [Sitecore Containers documentation](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/containers-in-sitecore-development.html). Together, these are meant to help you get started using [Docker](https://www.docker.com/) containers with Sitecore.
 
 Briefly, here's what you'll find in this repo:
 
@@ -9,7 +9,7 @@ Briefly, here's what you'll find in this repo:
 * Sample PowerShell scripts for container-based Sitecore instance preparation (`init.ps1`) and cleanup (`clean.ps1`).
 * Docker compose files for building Sitecore instances in various topologies (see `custom-images`).
 
-Please refer to the [Sitecore Containers documentation](https://containers.doc.sitecore.com/) for complete details, including running the examples and recommended usage.
+Please refer to the [Sitecore Containers documentation](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/containers-in-sitecore-development.html) for complete details, including running the examples and recommended usage.
 
 ## Are Docker Examples supported by Sitecore?
 
@@ -17,8 +17,8 @@ Sitecore maintains the Sitecore Containers documentation and Docker Examples, bu
 
 ## How can I get help with Docker Examples?
 
-Start with the [Sitecore Containers documentation](https://containers.doc.sitecore.com/). For technical issues in particular, check out the [Troubleshooting guide](https://containers.doc.sitecore.com/docs/troubleshooting).
+Start with the [Sitecore Containers documentation](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/containers-in-sitecore-development.html). For technical issues in particular, check out the [Troubleshooting guide](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/troubleshooting-docker.html)
 
-Beyond that, for usage questions regarding Docker Examples installation or code, or general questions about Sitecore Containers, please utilize [Sitecore Stackexchange](https://sitecore.stackexchange.com/) or [#docker](https://sitecorechat.slack.com/messages/docker) on [Sitecore Community Slack](https://sitecore.chat/).
+Beyond that, for usage questions regarding Docker Examples installation or code, or general questions about Sitecore Containers, please utilize [Sitecore StackExchange](https://sitecore.stackexchange.com/questions/tagged/docker) or [#docker](https://sitecorechat.slack.com/messages/docker) on [Sitecore Community Slack](https://sitecore.chat/).
 
 You can use GitHub to submit [issues](https://github.com/Sitecore/docker-examples/issues/new) for Docker Examples, but please do not submit usage questions.


### PR DESCRIPTION
I've updated links that went to containers.doc.sitecore.com to instead use direct doc.sitecore.com links, using the new 'latest' URL slug to ensure it always goes to the latest version of the docs.

While I was in there, I also updated the Sitecore StackExchange link to go directly to the Docker tag.