### PR TITLE
Update init.ps1 to store encoded values as string literals in env to …

### DIFF
--- a/getting-started/init.ps1
+++ b/getting-started/init.ps1
@@ -57,10 +57,10 @@ Set-EnvFileVariable "SITECORE_ADMIN_PASSWORD" -Value $SitecoreAdminPassword
 Set-EnvFileVariable "SQL_SA_PASSWORD" -Value $SqlSaPassword
 
 # TELERIK_ENCRYPTION_KEY = random 64-128 chars
-Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128)
+Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value "'(Get-SitecoreRandomString 128)'"
 
 # MEDIA_REQUEST_PROTECTION_SHARED_SECRET
-Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64)
+Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value "'(Get-SitecoreRandomString 64)'"
 
 # SITECORE_IDSECRET = random 64 chars
 Set-EnvFileVariable "SITECORE_IDSECRET" -Value (Get-SitecoreRandomString 64 -DisallowSpecial)

--- a/getting-started/init.ps1
+++ b/getting-started/init.ps1
@@ -57,10 +57,10 @@ Set-EnvFileVariable "SITECORE_ADMIN_PASSWORD" -Value $SitecoreAdminPassword
 Set-EnvFileVariable "SQL_SA_PASSWORD" -Value $SqlSaPassword
 
 # TELERIK_ENCRYPTION_KEY = random 64-128 chars
-Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value "'(Get-SitecoreRandomString 128)'"
+Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value "'$(Get-SitecoreRandomString 128)'"
 
 # MEDIA_REQUEST_PROTECTION_SHARED_SECRET
-Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value "'(Get-SitecoreRandomString 64)'"
+Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value "'$(Get-SitecoreRandomString 64)'"
 
 # SITECORE_IDSECRET = random 64 chars
 Set-EnvFileVariable "SITECORE_IDSECRET" -Value (Get-SitecoreRandomString 64 -DisallowSpecial)


### PR DESCRIPTION
…prevent parsing issues

Else you can get warnings such as:

time="2023-06-06T11:22:27-06:00" level=warning msg="The \"INsomeRandomstrPortion5r\" variable is not set. Defaulting to a blank string."