### PR TITLE
Fix "Getting Started" compose overrides

### DIFF
--- a/GettingStartedSetup/SetupDependecies/run/sitecore-xm1/docker-compose.override.yml
+++ b/GettingStartedSetup/SetupDependecies/run/sitecore-xm1/docker-compose.override.yml
@@ -116,11 +116,11 @@ services:
   # Use our retagged Identity Server image.
   # Configure for a mounted license file instead of using SITECORE_LICENSE.
   id:
-    image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-id6:${VERSION:-latest}
+    image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-id7:${VERSION:-latest}
     build:
       context: ../../docker/build/id
       args:
-        PARENT_IMAGE: ${SITECORE_DOCKER_REGISTRY}sitecore-id6:${SITECORE_VERSION}
+        PARENT_IMAGE: ${SITECORE_DOCKER_REGISTRY}sitecore-id7:${SITECORE_VERSION}
     volumes:
       - ${HOST_LICENSE_FOLDER}:c:\license
     environment:

--- a/GettingStartedSetup/SetupDependecies/run/sitecore-xp0/docker-compose.override.yml
+++ b/GettingStartedSetup/SetupDependecies/run/sitecore-xp0/docker-compose.override.yml
@@ -108,11 +108,11 @@ services:
   # Use our retagged Identity Server image.
   # Configure for a mounted license file instead of using SITECORE_LICENSE.
   id:
-    image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-id6:${VERSION:-latest}
+    image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-id7:${VERSION:-latest}
     build:
       context: ../../docker/build/id
       args:
-        PARENT_IMAGE: ${SITECORE_DOCKER_REGISTRY}sitecore-id6:${SITECORE_VERSION}
+        PARENT_IMAGE: ${SITECORE_DOCKER_REGISTRY}sitecore-id7:${SITECORE_VERSION}
     volumes:
       - ${HOST_LICENSE_FOLDER}:c:\license
     environment:

--- a/GettingStartedSetup/SetupDependecies/run/sitecore-xp1/docker-compose.override.yml
+++ b/GettingStartedSetup/SetupDependecies/run/sitecore-xp1/docker-compose.override.yml
@@ -116,11 +116,11 @@ services:
   # Use our retagged Identity Server image.
   # Configure for a mounted license file instead of using SITECORE_LICENSE.
   id:
-    image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-id6:${VERSION:-latest}
+    image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-id7:${VERSION:-latest}
     build:
       context: ../../docker/build/id
       args:
-        PARENT_IMAGE: ${SITECORE_DOCKER_REGISTRY}sitecore-id6:${SITECORE_VERSION}
+        PARENT_IMAGE: ${SITECORE_DOCKER_REGISTRY}sitecore-id7:${SITECORE_VERSION}
     volumes:
       - ${HOST_LICENSE_FOLDER}:c:\license
     environment:


### PR DESCRIPTION
Update id service image name from `id6` to `id7` in "Getting Started Setup" dependencies to match base compose.